### PR TITLE
add a --version option to the hook loader

### DIFF
--- a/docs/source/command_ref.rst
+++ b/docs/source/command_ref.rst
@@ -591,7 +591,9 @@ Other Commands
 virtualenvwrapper
 -----------------
 
-Print a list of commands and their descriptions as basic help output.
+Print a list of commands, their descriptions, and some details about
+the version and locations used by virtualenvwrapper as basic help
+output.
 
 Syntax::
 

--- a/tests/test_virtualenvwrapper.sh
+++ b/tests/test_virtualenvwrapper.sh
@@ -26,4 +26,16 @@ test_virtualenvwrapper_script_set() {
         "echo $VIRTUALENVWRAPPER_SCRIPT | grep -q /virtualenvwrapper.sh"
 }
 
+test_virtualenvwrapper_version() {
+    source "$test_dir/../virtualenvwrapper.sh"
+    typeset ver=$(_virtualenvwrapper_version)
+    assertTrue "version is empty" "[ -n $ver ]"
+}
+
+test_virtualenvwrapper_help_shows_version() {
+    source "$test_dir/../virtualenvwrapper.sh"
+    typeset pattern="Version: $(_virtualenvwrapper_version)"
+    assertTrue "version not in command output" "virtualenvwrapper | grep \"$pattern\""
+}
+
 . "$test_dir/shunit2"

--- a/virtualenvwrapper.sh
+++ b/virtualenvwrapper.sh
@@ -1336,8 +1336,13 @@ function allvirtualenv {
     unset IFS
 }
 
+function _virtualenvwrapper_version {
+    "$VIRTUALENVWRAPPER_PYTHON" -m 'virtualenvwrapper.hook_loader' --version
+}
+
 #:help:virtualenvwrapper: show this help message
 function virtualenvwrapper {
+    typeset version=$(_virtualenvwrapper_version)
 	cat <<EOF
 
 virtualenvwrapper is a set of extensions to Ian Bicking's virtualenv
@@ -1349,6 +1354,12 @@ introducing conflicts in their dependencies.
 For more information please refer to the documentation:
 
     http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html
+
+Version: $version
+Script: $VIRTUALENVWRAPPER_SCRIPT
+Python: $VIRTUALENVWRAPPER_PYTHON
+WORKON_HOME: $WORKON_HOME
+PROJECT_HOME: $PROJECT_HOME
 
 Commands available:
 

--- a/virtualenvwrapper/hook_loader.py
+++ b/virtualenvwrapper/hook_loader.py
@@ -79,8 +79,19 @@ def main():
         dest='names',
         default=[],
     )
+    parser.add_option(
+        '--version',
+        help='Show the version of virtualenvwrapper',
+        action='store_true',
+        default=False,
+    )
     parser.disable_interspersed_args()  # stop when on option without an '-'
     options, args = parser.parse_args()
+
+    if options.version:
+        import importlib.metadata
+        print(importlib.metadata.version('virtualenvwrapper'))
+        return 0
 
     root_logger = logging.getLogger('virtualenvwrapper')
 


### PR DESCRIPTION
Use the hook loader --version option to report the version of
virtualenvwrapper installed when the user runs the `virtualenvwrapper`
command.

Fixes #42