### PR TITLE
docs: update requirements for build on rtd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,3 +121,30 @@ jobs:
 
       - name: Run
         run: tox -e ${{ matrix.tox-environment }}
+
+  # Test build the docs
+  docs:
+    runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.ref, 'refs/tags') }}
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          # Pin this low because RTD doesn't seem to adopt new
+          # versions quickly and this ensures we don't have a
+          # dependency problem with importlib.metadata.
+          python-version: "3.9"
+
+      - name: Install dependencies
+        run: python -m pip install tox
+
+      - name: Run
+        run: tox -e docs

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -54,7 +54,7 @@ pull_request_rules:
   - name: Automatic merge on approval
     conditions:
       - and:
-        - "check-success=style (docs)"
+        - "check-success=docs"
         - "check-success=style (style)"
         - "check-success=style (pkglint)"
         - "check-success=Test macOS (3.8)"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 # sphinxcontrib-bitbucket
 # sphinx>=1.1.2,!=1.2.0,!=1.3b1,<1.3
 sphinx
+# We need importlib.metadata, which was added in 3.10.
+importlib_metadata;python_version<'3.10'


### PR DESCRIPTION
- Add importlib\_metadata dependency for older python versions, which
  seems to be what is used on RTD.
- Split the docs job out of the other style jobs and pin the version
  of Python to force the use of the separate library in CI builds of
  docs.
- Update the mergify rules accordingly.

See https://readthedocs.org/projects/virtualenvwrapper/builds/19455841/ for an example build failure.

```
Running Sphinx v1.8.6

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/virtualenvwrapper/envs/latest/lib/python3.7/site-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/virtualenvwrapper/envs/latest/lib/python3.7/site-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/virtualenvwrapper/checkouts/latest/docs/source/conf.py", line 16, in <module>
    import importlib.metadata
ModuleNotFoundError: No module named 'importlib.metadata'
```