### PR TITLE
pin python version in doc build test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
           # Pin this low because RTD doesn't seem to adopt new
           # versions quickly and this ensures we don't have a
           # dependency problem with importlib.metadata.
-          python-version: "3.9"
+          python-version: "3.7"
 
       - name: Install dependencies
         run: python -m pip install tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - 3.7
           - 3.8
           - 3.9
           - "3.10"

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ syntax: re
 ^web/
 .python-version
 .eggs
+/virtualenvwrapper/version.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,3 @@
 # sphinxcontrib-bitbucket
 # sphinx>=1.1.2,!=1.2.0,!=1.3b1,<1.3
 sphinx
-# We need importlib.metadata, which was added in 3.10.
-importlib_metadata;python_version<'3.10'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,8 @@
 # serve to show the default.
 
 import datetime
-import importlib.metadata
+
+import virtualenvwrapper.version
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -51,7 +52,7 @@ copyright = u'2009-%s, Doug Hellmann' % datetime.datetime.today().year
 # built documents.
 #
 # The short X.Y version.
-version = importlib.metadata.version('virtualenvwrapper')
+version = virtualenvwrapper.version.version
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 
 # https://github.com/pypa/setuptools_scm/
 [tool.setuptools_scm]
+write_to = "virtualenvwrapper/version.py"
 
 [project.urls]
 homepage = "https://virtualenvwrapper.readthedocs.io/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -27,7 +28,7 @@ dynamic = ["version"]
 keywords = ["virtualenv"]
 license = {text = "MIT"}
 readme = "README.txt"
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 
 dependencies = [
     "virtualenv",

--- a/tests/test_virtualenvwrapper.sh
+++ b/tests/test_virtualenvwrapper.sh
@@ -27,13 +27,13 @@ test_virtualenvwrapper_script_set() {
 }
 
 test_virtualenvwrapper_version() {
-    source "$test_dir/../virtualenvwrapper.sh"
+    load_wrappers
     typeset ver=$(_virtualenvwrapper_version)
     assertTrue "version is empty" "[ -n $ver ]"
 }
 
 test_virtualenvwrapper_help_shows_version() {
-    source "$test_dir/../virtualenvwrapper.sh"
+    load_wrappers
     typeset pattern="Version: $(_virtualenvwrapper_version)"
     assertTrue "version not in command output" "virtualenvwrapper | grep \"$pattern\""
 }

--- a/virtualenvwrapper/hook_loader.py
+++ b/virtualenvwrapper/hook_loader.py
@@ -13,8 +13,9 @@ import optparse
 import os
 import sys
 
-from stevedore import ExtensionManager
-from stevedore import NamedExtensionManager
+from stevedore import ExtensionManager, NamedExtensionManager
+
+import virtualenvwrapper.version
 
 LOG_FORMAT = '%(asctime)s %(levelname)s %(name)s %(message)s'
 
@@ -89,8 +90,7 @@ def main():
     options, args = parser.parse_args()
 
     if options.version:
-        import importlib.metadata
-        print(importlib.metadata.version('virtualenvwrapper'))
+        print(virtualenvwrapper.version.version)
         return 0
 
     root_logger = logging.getLogger('virtualenvwrapper')


### PR DESCRIPTION
RTD uses python 3.7

```
Using base prefix '/home/docs/.pyenv/versions/3.7.9'
New python executable in /home/docs/checkouts/readthedocs.org/user_builds/virtualenvwrapper/envs/latest/bin/python3.7
Also creating executable in /home/docs/checkouts/readthedocs.org/user_builds/virtualenvwrapper/envs/latest/bin/python
Installing setuptools, pip, wheel...
done.
```