### PR TITLE
Changed workon's env switching to use OR not $?

### DIFF
--- a/virtualenvwrapper.sh
+++ b/virtualenvwrapper.sh
@@ -759,16 +759,14 @@ function workon {
     # before switching so we use our override function,
     # if it exists, but make sure it's the deactivate function
     # we set up
-    type deactivate >/dev/null 2>&1
-    if [ $? -eq 0 ]
-    then
+    ! type deactivate >/dev/null 2>&1 || {
         typeset -f deactivate | grep 'typeset env_postdeactivate_hook' >/dev/null 2>&1
         if [ $? -eq 0 ]
         then
             deactivate
             unset -f deactivate >/dev/null 2>&1
         fi
-    fi
+    }
 
     virtualenvwrapper_run_hook "pre_activate" "$env_name"
 


### PR DESCRIPTION

Calling `type deactivate` by itself and using it's exit status breaks if caller is watching for **any** non-zero exit status.     
    
In my case, a GitLab CI pipeline with a runner calling `mkvirtualenv` as a Shell command.

Example pipeline output:
```
Executing "step_script" stage of the job script 00:01
$ . ~/.bashrc
$ mkvirtualenv -r requirements.txt "${ENV_ROOT}_${CI_COMMIT_BRANCH}"
created virtual environment CPython3.10.5.final.0-64 in 338ms
  creator CPython3Posix(dest=/home/gitlab-runner/.virtualenvs/project_a_master, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/gitlab-runner/.local/share/virtualenv)
    added seed packages: pip==23.0.1, setuptools==67.6.1, wheel==0.40.0
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
ERROR: Job failed: exit status 1
```

---

Tested change on:
* Rocky 9, bash (Gitlab-Runner)
* Pop! OS, bash & zsh
