### PR TITLE
Update the tested Python versions to match README

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -75,7 +75,7 @@ can download virtualenvwrapper-powershell_ from PyPI.
 Python Versions
 ===============
 
-virtualenvwrapper is tested under Python 2.7-3.6.
+virtualenvwrapper is tested under Python 3.8 - 3.11.
 
 .. _install-basic:
 


### PR DESCRIPTION
The following commit https://github.com/python-virtualenvwrapper/virtualenvwrapper/commit/af41484a4709503f6029830b91eb0ec0b4abb2a0 missed out on updating the tested Python versions in the documentation