### PR TITLE
Fix issues for python 3.12

### DIFF
--- a/tests/test_cp.sh
+++ b/tests/test_cp.sh
@@ -23,7 +23,7 @@ test_new_env_activated () {
     mkvirtualenv "source" >/dev/null 2>&1
 	RC=$?
 	assertEquals "0" "$RC"
-    (cd tests/testpackage && python setup.py install) >/dev/null 2>&1
+    (cd tests/testpackage && pip install .) >/dev/null 2>&1
     cpvirtualenv "source" "destination" >/dev/null 2>&1
     rmvirtualenv "source" >/dev/null 2>&1
     testscript="$(which testscript.py)"

--- a/tests/test_project_templates.sh
+++ b/tests/test_project_templates.sh
@@ -4,7 +4,7 @@ test_dir=$(dirname $0)
 source "$test_dir/setup.sh"
 
 oneTimeSetUp() {
-    (cd "$test_dir/testtemplate" && rm -rf build && "$VIRTUAL_ENV/bin/python" setup.py install)
+    (cd "$test_dir/testtemplate" && rm -rf build && "$VIRTUAL_ENV/bin/python" -m pip install .)
     rm -rf "$WORKON_HOME"
     mkdir -p "$WORKON_HOME"
     rm -rf "$PROJECT_HOME"

--- a/tests/test_wipeenv.sh
+++ b/tests/test_wipeenv.sh
@@ -20,7 +20,7 @@ tearDown() {
 
 test_wipeenv () {
     mkvirtualenv "wipetest" >/dev/null 2>&1
-    (cd tests/testpackage && python setup.py install) >/dev/null 2>&1
+    (cd tests/testpackage && pip install .) >/dev/null 2>&1
     before="$(pip freeze)"
     assertTrue "testpackage not installed" "pip freeze | grep testpackage"
     wipeenv >/dev/null 2>&1
@@ -52,7 +52,7 @@ test_wipeenv_pip_e () {
 
 test_wipeenv_develop () {
     mkvirtualenv "wipetest" >/dev/null 2>&1
-    (cd tests/testpackage && python setup.py develop) >/dev/null 2>&1
+    (cd tests/testpackage && pip install -e . --config-settings editable_mode=compat) >/dev/null 2>&1
     before="$(pip freeze)"
     assertTrue "testpackage not installed" "pip freeze | grep testpackage"
     wipeenv >/dev/null 2>&1

--- a/tests/testpackage/requirements.txt
+++ b/tests/testpackage/requirements.txt
@@ -1,0 +1,1 @@
+setuptools

--- a/tests/testtemplate/requirements.txt
+++ b/tests/testtemplate/requirements.txt
@@ -1,0 +1,1 @@
+setuptools

--- a/tests/testtemplate/setup.py
+++ b/tests/testtemplate/setup.py
@@ -5,102 +5,6 @@ VERSION = '1.0'
 
 from setuptools import setup, find_packages
 
-from distutils.util import convert_path
-from fnmatch import fnmatchcase
-
-import os
-import sys
-
-##############################################################################
-# find_package_data is an Ian Bicking creation.
-
-# Provided as an attribute, so you can append to these instead
-# of replicating them:
-standard_exclude = ('*.py', '*.pyc', '*~', '.*', '*.bak', '*.swp*')
-standard_exclude_directories = ('.*', 'CVS', '_darcs', './build',
-                                './dist', 'EGG-INFO', '*.egg-info')
-
-
-def find_package_data(
-        where='.', package='',
-        exclude=standard_exclude,
-        exclude_directories=standard_exclude_directories,
-        only_in_packages=True,
-        show_ignored=False):
-    """
-    Return a dictionary suitable for use in ``package_data``
-    in a distutils ``setup.py`` file.
-
-    The dictionary looks like::
-
-        {'package': [files]}
-
-    Where ``files`` is a list of all the files in that package that
-    don't match anything in ``exclude``.
-
-    If ``only_in_packages`` is true, then top-level directories that
-    are not packages won't be included (but directories under packages
-    will).
-
-    Directories matching any pattern in ``exclude_directories`` will
-    be ignored; by default directories with leading ``.``, ``CVS``,
-    and ``_darcs`` will be ignored.
-
-    If ``show_ignored`` is true, then all the files that aren't
-    included in package data are shown on stderr (for debugging
-    purposes).
-
-    Note patterns use wildcards, or can be exact paths (including
-    leading ``./``), and all searching is case-insensitive.
-
-    This function is by Ian Bicking.
-    """
-
-    out = {}
-    stack = [(convert_path(where), '', package, only_in_packages)]
-    while stack:
-        where, prefix, package, only_in_packages = stack.pop(0)
-        for name in os.listdir(where):
-            fn = os.path.join(where, name)
-            if os.path.isdir(fn):
-                bad_name = False
-                for pattern in exclude_directories:
-                    if (fnmatchcase(name, pattern)
-                        or fn.lower() == pattern.lower()):
-                        bad_name = True
-                        if show_ignored:
-                            print >> sys.stderr, (
-                                "Directory %s ignored by pattern %s"
-                                % (fn, pattern))
-                        break
-                if bad_name:
-                    continue
-                if os.path.isfile(os.path.join(fn, '__init__.py')):
-                    if not package:
-                        new_package = name
-                    else:
-                        new_package = package + '.' + name
-                    stack.append((fn, '', new_package, False))
-                else:
-                    stack.append((fn, prefix + name + '/', package, only_in_packages))
-            elif package or not only_in_packages:
-                # is a file
-                bad_name = False
-                for pattern in exclude:
-                    if (fnmatchcase(name, pattern)
-                        or fn.lower() == pattern.lower()):
-                        bad_name = True
-                        if show_ignored:
-                            print >> sys.stderr, (
-                                "File %s ignored by pattern %s"
-                                % (fn, pattern))
-                        break
-                if bad_name:
-                    continue
-                out.setdefault(package, []).append(prefix+name)
-    return out
-##############################################################################
-
 setup(
     name=PROJECT,
     version=VERSION,
@@ -130,13 +34,6 @@ setup(
 
     packages=find_packages(),
     include_package_data=True,
-    # Scan the input for package information
-    # to grab any data files (text, images, etc.)
-    # associated with sub-packages.
-    package_data=find_package_data('mytemplates',
-                                   package='mytemplates',
-                                   only_in_packages=False,
-                               ),
 
     entry_points={
         'virtualenvwrapper.project.template': [

--- a/virtualenvwrapper.sh
+++ b/virtualenvwrapper.sh
@@ -820,7 +820,7 @@ function virtualenvwrapper_get_python_version {
 
 # Prints the path to the site-packages directory for the current environment.
 function virtualenvwrapper_get_site_packages_dir {
-    "$VIRTUAL_ENV/$VIRTUALENVWRAPPER_ENV_BIN_DIR/python" -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib())"
+    "$VIRTUAL_ENV/$VIRTUALENVWRAPPER_ENV_BIN_DIR/python" -c "import sysconfig; print(sysconfig.get_path('platlib'))"
 }
 
 # Path management for packages outside of the virtual env.


### PR DESCRIPTION
Main things are the final removal of distutils and no setuptools by default in a venv.

Removed all of find_package_data because I didn't see its use, I could've removed just the distutils bits from it and it would've worked the same.

There should be consideration for the removal legacy develop install support and tests. https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior

Also used pip install instead python setup.py because its discouraged by setuptools, it allows me to opt out of using pip install -r requirements.txt and it allows PEP517 build systems to be added to the test packages at a later time without extra changes.

Tested for python3.8, python3.9, python3.10, python3.11 and python3.12 on Gentoo Linux.