### PR TITLE
[Docs] Update install.rst: fix inaccurate virtualenvwrapper.sh path

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -122,7 +122,7 @@ of the script installed with this package::
 
     export WORKON_HOME=$HOME/.virtualenvs
     export PROJECT_HOME=$HOME/Devel
-    source /usr/local/bin/virtualenvwrapper.sh
+    source ~/.local/bin/virtualenvwrapper.sh
 
 After editing it, reload the startup file (e.g., run ``source
 ~/.bashrc``).


### PR DESCRIPTION
Since Ubuntu ~12 or so, `virtualenvwrapper.sh` is installed to a different path than described in the documentation.

Related Issue: https://github.com/python-virtualenvwrapper/virtualenvwrapper/issues/53