### PR TITLE
Fix shell completion on FreeBSD

### DIFF
--- a/virtualenvwrapper.sh
+++ b/virtualenvwrapper.sh
@@ -586,7 +586,7 @@ function virtualenvwrapper_show_workon_options {
         | command \tr "\n" " " \
         | command \sed "s|/$VIRTUALENVWRAPPER_ENV_BIN_DIR/activate |/|g" \
         | command \tr "/" "\n" \
-        | command \sed "/^\s*$/d" \
+        | command \sed "/^[[:space:]]*$/d" \
         | (unset GREP_OPTIONS; command \grep -E -v '^\*$') 2>/dev/null
 }
 


### PR DESCRIPTION
sed on FreeBSD does not support '\s', and gives the error: "sed: 1: "/^\s*$/d": RE error: trailing backslash (\)"

Fix by using POSIX bracket expression '[[:space:]]'

Fixes [#65](https://github.com/python-virtualenvwrapper/virtualenvwrapper/issues/65)