### PR TITLE
Improve error message for IOErrors

### DIFF
--- a/virtualenvwrapper/hook_loader.py
+++ b/virtualenvwrapper/hook_loader.py
@@ -146,14 +146,15 @@ def main():
         log.debug('Saving sourcable %s hooks to %s',
                   hook, options.script_filename)
         options.sourcing = True
-        output = open(options.script_filename, "w")
         try:
-            output.write('# %s\n' % hook)
-            # output.write('echo %s\n' % hook)
-            # output.write('set -x\n')
-            run_hooks(hook + '_source', options, args, output)
-        finally:
-            output.close()
+            with open(options.script_filename, "w") as output:
+                output.write('# %s\n' % hook)
+                # output.write('echo %s\n' % hook)
+                # output.write('set -x\n')
+                run_hooks(hook + '_source', options, args, output)
+        except (IOError, OSError) as e:
+            log.error('Error while writing to %s: \n %s', options.script_filename, e)
+            sys.exit(1)
 
     return 0
 


### PR DESCRIPTION
Fixes #80.

If there is no space left in `/tmp`, the following output will be created now:
```
❯ ssh server.local
Last login: Sat Nov  4 13:54:02 2023 from 192.168.0.66
virtualenvwrapper.hook_loader Error while writing to /tmp/virtualenvwrapper-initialize-hook-VarTa4Ehmh: 
 [Errno 28] No space left on device
virtualenvwrapper.sh: There was a problem running the initialization hooks.

If Python could not import the module virtualenvwrapper.hook_loader,
check that virtualenvwrapper has been installed for
VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3 and that PATH is
set properly.
pi@server:~ $ 
```

In this scenario of a full tmp disk, the scond section of this error message is superfluous. It could be suppressed by
using a special exit code (e.g. exit code 2) to signal to the caller `virtualenvwrapper.sh` that initialization failed due to a full disk.

I do not know the error codes used by the `hook_script` or if there are any besides the non-zero=error),
thus I didn't feel confident about this idea. Let me know what you think about this!