### PR TITLE
Fixed broken link in install docs.

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -103,7 +103,7 @@ or::
 
 An alternative to installing it into the global site-packages is to
 add it to `your user local directory
-<https://docs.python.org/install/index.html#alternate-installation-the-user-scheme>`__
+<https://docs.python.org/3.11/install/index.html#alternate-installation-the-user-scheme>`__
 (usually `~/.local`).
 
 ::


### PR DESCRIPTION
With setup.py usage deprecated in Python 3.12, the install guide was removed from the docs. Pin link to 3.11 version, pending a fuller modernization.

Should fix the build errors seen on #82.