### PR TITLE
Fix for cd in unknown shells

### DIFF
--- a/virtualenvwrapper.sh
+++ b/virtualenvwrapper.sh
@@ -117,12 +117,11 @@ fi
 # cd because we are trying to change the state of the current shell,
 # so we use "builtin".
 function virtualenvwrapper_cd {
-    if [ -n "${BASH:-}" ]
-    then
-        builtin \cd "$@"
-    elif [ -n "${ZSH_VERSION:-}" ]
+    if [ -n "${ZSH_VERSION:-}" ]
     then
         builtin \cd -q "$@"
+    else
+        builtin \cd "$@"
     fi
 }
 


### PR DESCRIPTION
Make sure `virtualenvwrapper_cd` always tries to do something, even when it cannot infer the current shell. Assume Bourne-Shell compatible behavior by default.