### PR TITLE
Update mkvirtualenv help to document -p/--python option

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -57,7 +57,7 @@ or::
 Depending on your MSYS setup, you may need to install the `MSYS mktemp
 binary`_ in the ``MSYS_HOME/bin`` folder.
 
-.. _MSYS mktemp binary: https://sourceforge.net/projects/mingw/files/MSYS/
+.. _MSYS mktemp binary: https://sourceforge.net/projects/mingw/files/MSYS/Extension/mktemp/
 
 PowerShell
 ----------

--- a/virtualenvwrapper.sh
+++ b/virtualenvwrapper.sh
@@ -375,7 +375,7 @@ function virtualenvwrapper_verify_active_environment {
 
 # Help text for mkvirtualenv
 function virtualenvwrapper_mkvirtualenv_help {
-    echo "Usage: mkvirtualenv [-a project_path] [-i package] [-r requirements_file] [virtualenv options] env_name"
+    echo "Usage: mkvirtualenv [-a project_path] [-i package] [-r requirements_file] [-p python_interpreter] [virtualenv options] env_name"
     echo
     echo " -a project_path"
     echo

--- a/virtualenvwrapper.sh
+++ b/virtualenvwrapper.sh
@@ -391,6 +391,12 @@ function virtualenvwrapper_mkvirtualenv_help {
     echo
     echo "    Provide a pip requirements file to install a base set of packages"
     echo "    into the new environment."
+    echo
+    echo " -p python_interpreter, --python=python_interpreter"
+    echo
+    echo "    The Python interpreter to use for the new environment."
+    echo "    This can be specified as -p python3.8 or --python=/path/to/python"
+    echo
     echo;
     echo 'virtualenv help:';
     echo;


### PR DESCRIPTION
This pull request updates the `virtualenvwrapper_mkvirtualenv_help` function to include documentation for the `-p` and `--python` options when creating a new virtual environment with `mkvirtualenv`. It documents functionality that already exists in the script but was not previously mentioned in the help text.

Changes made:
- Added explanation of the `-p` and `--python` options in the help output
- Provided examples of how to use these options