### PR TITLE
remove hyperlink to msys project page

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -54,10 +54,9 @@ or::
     export MSYS_HOME=C:\msys\1.0
     source /usr/local/bin/virtualenvwrapper.sh
 
-Depending on your MSYS setup, you may need to install the `MSYS mktemp
-binary`_ in the ``MSYS_HOME/bin`` folder.
-
-.. _MSYS mktemp binary: https://sourceforge.net/projects/mingw/files/MSYS/
+Depending on your MSYS setup, you may need to install the MSYS mktemp binary
+(``https://sourceforge.net/projects/mingw/files/MSYS/``) in the
+``MSYS_HOME/bin`` folder.
 
 PowerShell
 ----------


### PR DESCRIPTION
Sourceforge returns 403 during our documentation
build if we use a real hyperlink with the
link-checker enabled. Replace the hyperlink with
inline text to the same URL.