### PR TITLE
Explicitly configure readthedocs conf.py path

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,8 @@
 version: 2
 
+sphinx:
+  configuration: docs/source/conf.py
+
 build:
   os: "ubuntu-20.04"
   tools:


### PR DESCRIPTION
RTD made a change that now requires it:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

This should fix the RTD CI job. (**Edit:** It do.)